### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,11 +110,12 @@
 					<p>Meetups are casual, regular gatherings where you can ask questions of your peers, and very likely, make a presentation yourself.</p>
 				</header>
 				<p>
-				    <a href="http://www.macbrained.org" target="" name="">MacBrained</a><br />
-				    <a href="https://mspmacadmins.org" target="" name="">MacBrained MSP</a><br />
+				    <a href="http://www.macbrained.org" target="" name="">Macbrained</a><br />
+				    <a href="https://mspmacadmins.org" target="" name="">Macbrained MSP</a><br />
 				    <a href="http://www.macadminmonthly.org" target="" name="">MacAdmin Monthly</a><br />
 				    <a href="https://www.meetup.com/Seattle-Apple-Admins" target="" name="">Seattle Mac Admins</a><br />
-				    <a href="http://www.londonappleadmins.org.uk" target="" name="">London Apple Admins</a>
+				    <a href="http://www.londonappleadmins.org.uk" target="" name="">London Apple Admins</a><br />
+				    <a href="https://twitter.com/macbrained_yvr"> target="" name="">Macbrained_YVR</a><br />
 				</p>
 				<header>
 					<h3>Conferences</h3>
@@ -239,7 +240,8 @@
 				    <a href="https://github.com/google/santa" target="" name="">Santa</a> - Binary whitelisting agent for macOS<br />
 				    <a href="https://osquery.io" target="" name="">OSQuery</a> - Endpoint visibiulity<br />
 				    <a href="https://zentral.io" target="" name="">Zentral</a> - Endpoint monitoring<br />
-				    <a href="https://eclecticlight.co/2016/12/27/lockrattler-2-0-a-quick-check-of-more-macos-security-protection-systems-update/" target="" name="">Lock Rattler</a> - Quickly check a Mac's security settings
+				    <a href="https://eclecticlight.co/2016/12/27/lockrattler-2-0-a-quick-check-of-more-macos-security-protection-systems-update/" target="" name="">Lock Rattler</a> - Quickly check a Mac's security settings<br />
+				    <a href="https://lists.apple.com/mailman/listinfo/security-announce/" target="" name="">Apple Security Announce Mail List</a>
 				</p>
 			</section>
 			<section>


### PR DESCRIPTION
Added the apple security announce list, and a link to the macbrained_yvr twitter.

MacBrained was also typed wrong. It should just be Macbrained (no caps on the b)