### PR TITLE
Fixed markdown links that should have been HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
       <header>
         <h2 id="interaction">Interaction</h2>
         <p>Reading and experimenting are great. However, meeting up with your peers just can't be beat. This section is broken
-        into meetups: often monthly, and just for an evening, conferences: typically multi-day, annual events, and online: mailing lists, 
+        into meetups: often monthly, and just for an evening, conferences: typically multi-day, annual events, and online: mailing lists,
         message boards, and chat resources.</p>
       </header>
       <section>
@@ -181,7 +181,7 @@
         </p>
       </section>
     </article>
-    
+
     <!-- Books -->
     <article class="container box style3">
       <header>
@@ -228,7 +228,7 @@
           </p>
       </section>
     </article>
-    
+
     <!-- Management Tools -->
     <article class="container box style3" style="background: #FFFFFF">
       <header>
@@ -250,7 +250,7 @@
             <a href="https://github.com/wdas/reposado" target="" name="">Reposado</a> - Apple software update mirroring
         </p>
     </article>
-    
+
     <!-- Admin Software -->
     <article class="container box style3">
       <header>
@@ -269,7 +269,7 @@
           <a href="http://www.mothersruin.com/software/SuspiciousPackage/" target="" name="">Suspicious Package</a> - Quicklook a peek into packages
       </p>
     </article>
-    
+
     <!-- Security -->
     <article class="container box style3" style="background: #FFFFFF">
       <header>
@@ -303,7 +303,7 @@
         </p>
       </section>
     </article>
-    
+
     <!-- Personal Development -->
     <article class="container box style3">
       <header>
@@ -320,7 +320,7 @@
         </p>
       </section>
     </article>
-    
+
     <!-- Jobs -->
     <article class="container box style3" style="background: #FFFFFF">
       <header>
@@ -334,7 +334,7 @@
           <a href="http://eligo.co.uk/apple-mac-recruitment/" target="" name="">Eligo (UK)</a>
       </p>
     </article>
-    
+
     <!-- More lists -->
     <article class="container box style3">
       <header>
@@ -350,12 +350,14 @@
             <a href="https://github.com/neilmartin83/all-the-macadmin-conference-videos/blob/master/README.md" target="" name="">all-the-macadmin-conference-videos</a> - List of the video feeds/channels from varios Mac Admin conferences and Meetups
        </p>
     </article>
-    
+
     <!-- Contribute -->
     <article class="container box style3" style="background: #FFFFFF">
       <header>
         <h2 id="contribute">Contribute!</h2>
-        <p>This is a community resource. This site is <a href="https://github.com/macadmininfo/macadmininfo.github.io" target="" name="">hosted on GitHub</a>, so please send [pull requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to add, update, or offer corrections, or file a [new issue](https://github.com/macadmininfo/macadmininfo.github.io/issues/new).</p>
+        <p>This is a community resource. This site is <a href="https://github.com/macadmininfo/macadmininfo.github.io" target="" name="">hosted on GitHub</a>,
+          so please send <a href="https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request" target="" name="">pull requests</a>
+          to add, update, or offer corrections, or file a <a href="https://github.com/macadmininfo/macadmininfo.github.io/issues/new" target="" name="">new issue</a>.</p>
       </header>
       <section>
         <header>


### PR DESCRIPTION
These were overflowing the viewport without using word wrap and causing horizontal scroll on mobile.

Looks like my editor also cleaned up some extraneous whitespace.