### PR TITLE
fix version in office resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
             <a href="https://groups.google.com/forum/#!forum/munki-discuss" target="" name="">Munki User Mailing List</a><br />
             <a href="https://groups.google.com/forum/#!forum/autopkg-discuss" target="" name="">AutoPkg (command line tool) Mailing List</a><br />
             <a href="https://groups.google.com/forum/#!forum/autopkgr-discuss" target="" name="">AutoPkgr (GUI app) Mailing List</a><br />
-            <a href="https://macadmins.software" target="" name="">Microsoft Office 2016 Resources</a>
+            <a href="https://macadmins.software" target="" name="">Microsoft Office for Mac Resources</a>
         </p>
       </section>
     </article>


### PR DESCRIPTION
resources are for all versions of Office for Mac, not just 2016