### PR TITLE
Take out imagr

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,6 @@
       </header>
       <p>
           <a href="https://github.com/MagerValp/AutoDMG" target="" name="">AutoDMG</a> - Create deployable system images.<br />
-          <a href="https://github.com/grahamgilbert/imagr" target="" name="">Imagr</a> - Image machines from a NetBoot environment.<br />
           <a href="http://s.sudre.free.fr/Software/Packages/about.html" target="" name="">Packages</a> - A package-building utility.<br />
           <a href="https://autopkg.github.io/autopkg/" target="" name="">AutoPKG</a> - Automate package building with the help of the community.<br />
           <a href="https://github.com/unixorn/luggage" target="" name="">The Luggage</a> - Repeatable, reviewable package automation.<br />


### PR DESCRIPTION
Imagr isn't best practice anymore, we shouldn't promote it's use.