### PR TITLE
Add Pareto Security MenuBar app to the list of security apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,7 @@
             <a href="https://github.com/grahamgilbert/crypt" target="" name="">Crypt</a> - FileVault encryption and key escrow solution.<br />
             <a href="https://github.com/google/cauliflowervest" target="" name="">Cauliflower Vest</a> - Scalable key escrow solution for FileVault, BitLocker, LUKS, and Duplicity.<br />
             <a href="https://zentral.io" target="" name="">Zentral</a> - Endpoint monitoring<br />
+            <a href="https://paretosecurity.com" target="" name="">Pareto Security</a> - MenuBar app to promote basic security hygiene<br />
             <a href="https://objective-see.com/index.html" name="">Objective-See Security Tools</a><br />
             <a href="https://eclecticlight.co/2016/12/27/lockrattler-2-0-a-quick-check-of-more-macos-security-protection-systems-update/" target="" name="">Lock Rattler</a> - Quickly check a Mac's security settings<br />
             <a href="https://lists.apple.com/mailman/listinfo/security-announce/" target="" name="">Apple Security Announce Mail List</a>


### PR DESCRIPTION
Not really aimed at Mac admins themselves, but to help them nudge regular users into better security habits.